### PR TITLE
Add destroy user along with user's artilces

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
-    before_action :set_user, only: [:show, :edit, :update]
+    before_action :set_user, only: [:show, :edit, :update, :destroy]
     before_action :require_user, only: [:edit, :update]
-    before_action :require_same_user, only: [:edit, :update, ]
+    before_action :require_same_user, only: [:edit, :update, :destroy]
 
     def index
         @users = User.paginate(page: params[:page], per_page: 5)
@@ -40,6 +40,13 @@ class UsersController < ApplicationController
         else
             render 'new'
         end
+    end
+
+    def destroy
+       @user.destroy
+       session[:user_id] = nil
+       flash[:notice] = "Account and all associated successfully deleted"
+       redirect_to @user
     end
 
     private 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
     before_save { self.email = email.downcase }
-    has_many :articles
+    has_many :articles, dependent: :destroy
     validates  :username, presence: true, 
                           uniqueness: { case_sensitive: false }, 
                           length: { minimum: 3, maximum: 25 }

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -32,6 +32,7 @@
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <%= link_to "View your profile", user_path(current_user), class: "dropdown-item" %>
                 <%= link_to "Edit your profile", edit_user_path(current_user), class: "dropdown-item" %>
+                <%= link_to "Delete profile", user_path(current_user), class: "text-danger dropdown-item", method: :delete, data: { confirm: "Are you sure?" } %>
                 </div>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
- Added functionality for users to delete their own accounts using a destroy method in the users controller.

- Added a link to delete account to the users' profile dropdown navigation option.

- Utilized a couple of existing methods (as before_action methods) to secure the newly created destroy action at controller level.