### PR TITLE
Add admin column to user table

### DIFF
--- a/db/migrate/20211207111101_add_admin_to_users.rb
+++ b/db/migrate/20211207111101_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users,  :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_03_162124) do
+ActiveRecord::Schema.define(version: 2021_12_07_111101) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_162124) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
+    t.boolean "admin", default: false
   end
 
 end


### PR DESCRIPTION
- Generated migration file to add admin field to users table, with a default value of false for all users.

Whether a user is admin or not can be tested by first getting a user object in the rails console and checking user.admin? from there.

To switch a user to an admin user you can use the following command in the rails console (assuming you have already selected a user object):

user.toggle!(:admin)