### PR TITLE
Add controller test to ensure categories cannot be created by non-admins.

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,6 @@
 class CategoriesController < ApplicationController
-    
+    before_action :require_admin, except: [:index, :show]
+
     def new
         @category = Category.new
     end
@@ -25,8 +26,16 @@ class CategoriesController < ApplicationController
     end
 
     private
+    private
 
     def category_params
         params.require(:category).permit(:name)        
+    end
+
+    def require_admin
+        if !(logged_in? && current_user.admin?)
+            flash[:alert] = "Only admin can perform that action"
+            redirect_to categories_path
+        end
     end
 end

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class CategoriesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @category = Category.create(name: "Sports")
+    @admin_user = User.create(username: "johnsmith", email: "johnsmith@email.com",password: "password",
+                              admin: true)
   end
 
   test "should get index" do
@@ -11,11 +13,13 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get new" do
+    sign_in_as(@admin_user)
     get new_category_url
     assert_response :success
   end
 
   test "should create category" do
+    sign_in_as(@admin_user)
     assert_difference('Category.count', 1) do
       post categories_url, params: { category: { name: "Travel" } }
     end
@@ -23,8 +27,16 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to category_url(Category.last)
   end
 
+  test "should not create category if not admin" do
+    assert_no_difference('Category.count') do
+      post categories_url, params: { category: { name: "Travel" } }
+    end
+
+    assert_redirected_to categories_url
+  end
+
   test "should show category" do
-    get category_url(@category)
+    get categories_url(@category)
     assert_response :success
   end
 

--- a/test/integration/create_category_test.rb
+++ b/test/integration/create_category_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class CreateCategoryTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @admin_user = User.create(username: "johnsmith", email: "johnsmith@email.com",password: "password",
+                              admin: true)
+    sign_in_as(@admin_user)
+  end
+
   test "get new category form and create category " do
     get "/categories/new"
     assert_response :success
@@ -14,7 +21,7 @@ class CreateCategoryTest < ActionDispatch::IntegrationTest
   end
 
   # error messages
-  test "get new category form and reject invalid categoy submission " do
+  test "get new category form and reject invalid category submission " do
     get "/categories/new"
     assert_response :success
     assert_no_difference 'Category.count' do

--- a/test/integration/list_categories_test.rb
+++ b/test/integration/list_categories_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class ListCategoriesTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @category = Category.create(name: "Sports")
+    @category2 = Category.create(name: "Travel")
+  end
+
+  test "should show categories listing" do
+    get "/categories"
+    assert_select "a[href=?]", category_path(@category), text: @category.name
+    assert_select "a[href=?]", category_path(@category2), text: @category2.name
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,4 +10,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+   def sign_in_as(user)
+     post login_path, params: {session: {email: user.email, password: "password"}}
+   end
 end


### PR DESCRIPTION
- Add controller test to ensure categories cannot be created by non-admins.

- Add require_admin method (private) to categories controller and use it as before_action for new and create actions.

- Create admin user in categories controller test and sign the user in for new and create action tests.

- Build sign_in_as helper method to test_helper.rb file, so it can be used to sign users in for tests.

- Modify categories integration test file to create and sign a user in (as admin) in order to proceed with the tests.