### PR TITLE
Add category list to the create article

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,6 +18,7 @@ class ArticlesController < ApplicationController
     end
 
     def create
+        byebug
        @article = Article.new(article_params)
        @article.user = current_user
         if @article.save
@@ -50,7 +51,7 @@ class ArticlesController < ApplicationController
     end
 
     def article_params
-        params.require(:article).permit(:title, :description)
+        params.require(:article).permit(:title, :description, category_ids: [])
     end
 
     def require_same_user

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -6,7 +6,7 @@
             <div class"form-group row mx-auto">
                 <%= f.label :title, class: "col-form-label" %>
                 <div class="">
-                    <%= f.text_field :title, class: "form-control" %>
+                    <%= f.text_field :title, class: "form-control shadow rounded" %>
                 </div>
             </div>
 
@@ -15,9 +15,20 @@
             <div class"form-group row">
                 <%= f.label :description, class: "col-form-label"%>
                 <div class="">
-                <%= f.text_area :description,  rows: 10, class: "form-control" %>
+                <%= f.text_area :description,  rows: 10, class: "form-control shadow rounded" %>
                 </div>
             </div>
+
+
+            <div class"form-group row">
+              <%= f.label :category, class: "col-form-label"%>
+              <div class="">
+                <%= f.collection_select :category_ids, Category.all, :id, :name,
+                                        {prompt:  "Make your selection from the list below (can be empty)"},
+                                        {:multiple => true, size: 4,  class: "custom-select shadow rounded"}  %>
+              </div>
+            </div>
+
 
             <div class="form-group row justify-content-center mt-4">
                 <%= f.submit class: "btn btn-outline-info btn-lg" %>


### PR DESCRIPTION
- White-list category ids in article_params method of the articles controller.

- Add select box for categories to _form.html.erb (form partial) used for articles (views/articles/_form.html.erb).